### PR TITLE
Mecg-e

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "code/denoising/denoising_models/ECG-processing"]
 	path = mycode/denoising/denoising_models/ECG-processing
 	url = https://github.com/Basile-73/ECG-processing.git
+[submodule "mycode/denoising/denoising_models/my_MECG-E"]
+	path = mycode/denoising/denoising_models/my_MECG-E
+	url = https://github.com/Basile-73/my_MECG-E.git

--- a/mycode/denoising/denoising_utils/utils.py
+++ b/mycode/denoising/denoising_utils/utils.py
@@ -8,6 +8,7 @@ from torch.utils.data import Dataset, DataLoader
 from typing import Tuple, Optional
 import sys
 import os
+import yaml
 
 
 # ============================================================================
@@ -240,6 +241,10 @@ def get_model(model_type: str, input_length: int = 5000,
     ecg_processing_path = os.path.join(os.path.dirname(__file__), '../denoising_models/ECG-processing')
     sys.path.insert(0, ecg_processing_path)
 
+    # Add my_MECG-E folder to path (it's in denoising_models/my_MECG-E)
+    mecge_path = os.path.join(os.path.dirname(__file__), '../denoising_models/my_MECG-E')
+    sys.path.insert(0, mecge_path)
+
     model_type = model_type.lower()
 
     if model_type == 'fcn':
@@ -258,6 +263,51 @@ def get_model(model_type: str, input_length: int = 5000,
         from Stage2_model3 import DRnet
         base_model = DRnet(in_channels=2)  # 2 channels: noisy + stage1 output
         model = DenoisingModelWrapper(base_model, input_length)
+    elif model_type == 'mecge_phase':
+        # Load MECGE with phase feature configuration
+        config_path = os.path.join(os.path.dirname(__file__), '../denoising_models/my_MECG-E/config/MECGE_phase.yaml')
+        with open(config_path, 'r') as f:
+            config = yaml.safe_load(f)
+        from models.MECGE import MECGE
+        model = MECGE(config)
+
+        if pretrained_path and os.path.exists(pretrained_path):
+            model.load_state_dict(torch.load(pretrained_path))
+
+        n_params = sum(p.numel() for p in model.parameters() if p.requires_grad)
+        print(f"Loaded {model_type} with {n_params:,} parameters")
+
+        return model
+    elif model_type == 'mecge_complex':
+        # Load MECGE with complex feature configuration
+        config_path = os.path.join(os.path.dirname(__file__), '../denoising_models/my_MECG-E/config/MECGE_complex.yaml')
+        with open(config_path, 'r') as f:
+            config = yaml.safe_load(f)
+        from models.MECGE import MECGE
+        model = MECGE(config)
+
+        if pretrained_path and os.path.exists(pretrained_path):
+            model.load_state_dict(torch.load(pretrained_path))
+
+        n_params = sum(p.numel() for p in model.parameters() if p.requires_grad)
+        print(f"Loaded {model_type} with {n_params:,} parameters")
+
+        return model
+    elif model_type == 'mecge_wav':
+        # Load MECGE with waveform feature configuration
+        config_path = os.path.join(os.path.dirname(__file__), '../denoising_models/my_MECG-E/config/MECGE_wav.yaml')
+        with open(config_path, 'r') as f:
+            config = yaml.safe_load(f)
+        from models.MECGE import MECGE
+        model = MECGE(config)
+
+        if pretrained_path and os.path.exists(pretrained_path):
+            model.load_state_dict(torch.load(pretrained_path))
+
+        n_params = sum(p.numel() for p in model.parameters() if p.requires_grad)
+        print(f"Loaded {model_type} with {n_params:,} parameters")
+
+        return model
     else:
         raise ValueError(f"Unknown model name: {model_type}")
 

--- a/tests/test_mecge_forward.py
+++ b/tests/test_mecge_forward.py
@@ -1,0 +1,170 @@
+"""
+Test script for MECGE model forward pass.
+Tests the model with different configurations (phase, complex, wav features).
+"""
+
+import sys
+import os
+import torch
+import yaml
+
+# Add the MECG-E models directory to the path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'mycode', 'denoising', 'denoising_models', 'my_MECG-E', 'models'))
+
+from MECGE import MECGE
+
+
+def load_config(config_path):
+    """Load configuration from YAML file."""
+    with open(config_path, 'r') as f:
+        config = yaml.safe_load(f)
+    return config
+
+
+def test_forward_pass(config_path, feature_type='pha', batch_size=2, signal_length=1000):
+    """
+    Test the forward pass of MECGE model.
+
+    Args:
+        config_path: Path to the configuration YAML file
+        feature_type: Type of feature ('pha', 'cpx', 'wav')
+        batch_size: Batch size for test
+        signal_length: Length of input signal
+    """
+    print(f"\n{'='*60}")
+    print(f"Testing MECGE model with feature type: {feature_type}")
+    print(f"{'='*60}")
+
+    # Check for GPU availability
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    print(f"Using device: {device}")
+    if device.type == 'cuda':
+        print(f"  GPU: {torch.cuda.get_device_name(0)}")
+        print(f"  Memory: {torch.cuda.get_device_properties(0).total_memory / 1e9:.2f} GB")
+
+    # Load config
+    config = load_config(config_path)
+    print(f"\nConfig loaded from: {config_path}")
+    print(f"Model parameters:")
+    for key, value in config['model'].items():
+        print(f"  {key}: {value}")
+
+    # Initialize model
+    try:
+        model = MECGE(config)
+        model = model.to(device)
+        model.eval()
+        print(f"\n✓ Model initialized successfully and moved to {device}")
+
+        # Count parameters
+        total_params = sum(p.numel() for p in model.parameters())
+        trainable_params = sum(p.numel() for p in model.parameters() if p.requires_grad)
+        print(f"  Total parameters: {total_params:,}")
+        print(f"  Trainable parameters: {trainable_params:,}")
+
+    except Exception as e:
+        print(f"\n✗ Model initialization failed: {e}")
+        return False
+
+    # Create dummy input tensors
+    # Shape: [batch_size, channels, time_steps]
+    clean_audio = torch.randn(batch_size, 1, signal_length).to(device)
+    noisy_audio = clean_audio + torch.randn_like(clean_audio) * 0.1
+
+    print(f"\nInput shapes:")
+    print(f"  clean_audio: {clean_audio.shape} on {clean_audio.device}")
+    print(f"  noisy_audio: {noisy_audio.shape} on {noisy_audio.device}")
+
+    # Test forward pass (training mode)
+    try:
+        model.train()
+        loss = model(clean_audio, noisy_audio)
+        print(f"\n✓ Training forward pass successful")
+        print(f"  Loss value: {loss.item():.6f}")
+        print(f"  Loss shape: {loss.shape}")
+
+        # Test backward pass
+        loss.backward()
+        print(f"✓ Backward pass successful")
+
+    except Exception as e:
+        print(f"\n✗ Training forward pass failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+    # Test inference (denoising mode)
+    try:
+        model.eval()
+        with torch.no_grad():
+            denoised_audio = model.denoising(noisy_audio)
+        print(f"\n✓ Inference (denoising) pass successful")
+        print(f"  Output shape: {denoised_audio.shape}")
+        print(f"  Input signal range: [{noisy_audio.min():.4f}, {noisy_audio.max():.4f}]")
+        print(f"  Output signal range: [{denoised_audio.min():.4f}, {denoised_audio.max():.4f}]")
+
+    except Exception as e:
+        print(f"\n✗ Inference pass failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+    print(f"\n{'='*60}")
+    print(f"✓ All tests passed for {feature_type} feature type!")
+    print(f"{'='*60}\n")
+
+    return True
+
+
+def main():
+    """Run tests for all feature types."""
+
+    # Get the base directory
+    base_dir = os.path.join(os.path.dirname(__file__), '..', 'mycode', 'denoising', 'denoising_models', 'my_MECG-E')
+    config_dir = os.path.join(base_dir, 'config')
+
+    # Test configurations
+    test_configs = [
+        (os.path.join(config_dir, 'MECGE_phase.yaml'), 'pha'),
+        (os.path.join(config_dir, 'MECGE_complex.yaml'), 'cpx'),
+        (os.path.join(config_dir, 'MECGE_wav.yaml'), 'wav'),
+    ]
+
+    results = {}
+
+    print("\n" + "="*60)
+    print("MECGE Model Forward Pass Test Suite")
+    print("="*60)
+
+    for config_path, feature_type in test_configs:
+        if not os.path.exists(config_path):
+            print(f"\n⚠ Config file not found: {config_path}")
+            results[feature_type] = False
+            continue
+
+        try:
+            success = test_forward_pass(config_path, feature_type)
+            results[feature_type] = success
+        except Exception as e:
+            print(f"\n✗ Test failed for {feature_type}: {e}")
+            import traceback
+            traceback.print_exc()
+            results[feature_type] = False
+
+    # Summary
+    print("\n" + "="*60)
+    print("Test Summary")
+    print("="*60)
+    for feature_type, success in results.items():
+        status = "✓ PASSED" if success else "✗ FAILED"
+        print(f"{feature_type:10s}: {status}")
+    print("="*60)
+
+    # Return exit code
+    all_passed = all(results.values())
+    return 0 if all_passed else 1
+
+
+if __name__ == '__main__':
+    exit_code = main()
+    sys.exit(exit_code)

--- a/tests/test_shapes.py
+++ b/tests/test_shapes.py
@@ -1,0 +1,7 @@
+# load ../data/physionet.org/files/ptb-xl/1.0.3/raw100.npy and print its shape
+import numpy as np
+data = np.load('data/physionet.org/files/ptb-xl/1.0.3/raw100.npy', allow_pickle=True)
+print(data.shape)
+
+data = np.load('mycode/denoising/output/exp_denoising_norm_channel/data/clean_train.npy', allow_pickle=True)
+print(data.shape)


### PR DESCRIPTION
This pull request adds support for the new state-of-the-art MECG-E (Mamba-based ECG Enhancer) models to the denoising pipeline. It introduces the MECG-E model variants, updates documentation with usage instructions and troubleshooting, and refactors the codebase to seamlessly handle MECG-E's unique training and inference interfaces. The changes ensure that MECG-E models are automatically detected and integrated, requiring minimal effort from users.

**MECG-E Model Integration:**

* Added MECG-E as a new submodule (`mycode/denoising/denoising_models/my_MECG-E`) and registered it in `.gitmodules`, enabling access to the latest Mamba-based ECG denoiser. [[1]](diffhunk://#diff-fe7afb5c9c916e521401d3fcfb4277d5071798c3baf83baf11d6071742823584R4-R6) [[2]](diffhunk://#diff-bf77ed72fab55ef43ad0577d2778a28f35984947fea452cff3fceb74b06cc235R1)
* Refactored model training, inference, and evaluation utilities (`qui_plot.py`, `rmse_analysis.py`, `training.py`) to automatically detect MECG-E models and use their custom interfaces for loss computation and prediction. This includes guards for unsupported Stage2 usage and unified inference via the new `run_denoise_inference` helper. [[1]](diffhunk://#diff-3ef588a09d36ae64da2fbd65679bcbff6e2d7f1bdf76ed6e6923cb6d202b9343L17-R17) [[2]](diffhunk://#diff-3ef588a09d36ae64da2fbd65679bcbff6e2d7f1bdf76ed6e6923cb6d202b9343R196-R202) [[3]](diffhunk://#diff-3ef588a09d36ae64da2fbd65679bcbff6e2d7f1bdf76ed6e6923cb6d202b9343L204-R212) [[4]](diffhunk://#diff-3ef588a09d36ae64da2fbd65679bcbff6e2d7f1bdf76ed6e6923cb6d202b9343R227-R237) [[5]](diffhunk://#diff-3ef588a09d36ae64da2fbd65679bcbff6e2d7f1bdf76ed6e6923cb6d202b9343L239-R259) [[6]](diffhunk://#diff-8121ea6bf3c07cac7f74a2927bb59612639b4b3c35da187e7d09883b7f7a04d8R12-R15) [[7]](diffhunk://#diff-8121ea6bf3c07cac7f74a2927bb59612639b4b3c35da187e7d09883b7f7a04d8R138-R153) [[8]](diffhunk://#diff-8121ea6bf3c07cac7f74a2927bb59612639b4b3c35da187e7d09883b7f7a04d8R166-R176) [[9]](diffhunk://#diff-8121ea6bf3c07cac7f74a2927bb59612639b4b3c35da187e7d09883b7f7a04d8L176-R197) [[10]](diffhunk://#diff-5e8f65a708bed7a39f83596576a05593c17ae80caa5d7d4aa74ee14196843e45R33-R39) [[11]](diffhunk://#diff-5e8f65a708bed7a39f83596576a05593c17ae80caa5d7d4aa74ee14196843e45R81-R90) [[12]](diffhunk://#diff-5e8f65a708bed7a39f83596576a05593c17ae80caa5d7d4aa74ee14196843e45R108-R116) [[13]](diffhunk://#diff-5e8f65a708bed7a39f83596576a05593c17ae80caa5d7d4aa74ee14196843e45R171-R199)

**Documentation and Usage:**

* Updated `mycode/denoising/0_README.md` with detailed descriptions of MECG-E variants, YAML configuration requirements, usage examples, and troubleshooting steps for common issues (submodule setup, config files, CUDA requirements). Added reference to the MECG-E publication. [[1]](diffhunk://#diff-d78df4bb71a4075bcf2f595aa9c78966732b21fc31eabececbee9067751d0440R116-R122) [[2]](diffhunk://#diff-d78df4bb71a4075bcf2f595aa9c78966732b21fc31eabececbee9067751d0440R207-R301) [[3]](diffhunk://#diff-d78df4bb71a4075bcf2f595aa9c78966732b21fc31eabececbee9067751d0440R378-R424) [[4]](diffhunk://#diff-d78df4bb71a4075bcf2f595aa9c78966732b21fc31eabececbee9067751d0440R476-R489) [[5]](diffhunk://#diff-d78df4bb71a4075bcf2f595aa9c78966732b21fc31eabececbee9067751d0440R504) [[6]](diffhunk://#diff-d78df4bb71a4075bcf2f595aa9c78966732b21fc31eabececbee9067751d0440R522-R540)

**Dependency Management:**

* Documented MECG-E specific dependencies, including the Mamba SSM package and CUDA version requirements, with installation instructions for seamless setup.

**Pipeline Robustness:**

* Added troubleshooting guidance for MECG-E import errors and configuration issues, ensuring users can resolve setup problems quickly.

**Reference Update:**

* Cited the MECG-E publication in the README to acknowledge its scientific contribution.